### PR TITLE
P2/P3: Booking discovery + weekly schedule error UX

### DIFF
--- a/public/locales/en/booking.json
+++ b/public/locales/en/booking.json
@@ -48,5 +48,15 @@
     "bestWishes":"Wishing you great health!",
     "errMissingImportantInfo": "Missing important information",
     "errTextMissingImportantInfo": "You need to set your information",
-    "addressRequiredForBooking": "Please update your address to book an appointment"
+    "addressRequiredForBooking": "Please update your address to book an appointment",
+    "filterBySpecialty": "Filter by specialty",
+    "allSpecialties": "All",
+    "searchDoctor": "Search doctor by name",
+    "filterByDate": "Available on date",
+    "clearDateFilter": "Clear date filter",
+    "noDoctorMatch": "No doctors match your filters",
+    "selectedDoctor": "Selected doctor",
+    "changeDoctor": "Change doctor",
+    "slotUnavailableTitle": "Time slot unavailable",
+    "slotUnavailable": "This hour is already taken or unavailable. Please pick another time."
 }

--- a/public/locales/en/doctor-schedule.json
+++ b/public/locales/en/doctor-schedule.json
@@ -16,5 +16,7 @@
     "week": "Week",
     "doctorScheduleTitle": "Doctor Weekly Schedule Statistics",
     "confirmCreateSchedule": "Confirm to create this week schedule?",
-    "confirmUpdateSchedule": "Confirm to update this week schedule?"
+    "confirmUpdateSchedule": "Confirm to update this week schedule?",
+    "updateBlockedTitle": "Cannot update weekly schedule",
+    "updateBlockedHasBookings": "This week already has patient bookings. Cancel or reassign them before updating your working sessions."
 }

--- a/public/locales/vi/booking.json
+++ b/public/locales/vi/booking.json
@@ -48,5 +48,15 @@
     "bestWishes": "Chúc bạn thật nhiều sức khỏe!",
     "errMissingImportantInfo": "Thiếu thông tin quan trọng",
     "errTextMissingImportantInfo": "Bạn cần cài đặt thông tin quan trọng",
-    "addressRequiredForBooking": "Vui lòng cập nhật địa chỉ để có thể đặt lịch khám"
+    "addressRequiredForBooking": "Vui lòng cập nhật địa chỉ để có thể đặt lịch khám",
+    "filterBySpecialty": "Lọc theo chuyên khoa",
+    "allSpecialties": "Tất cả",
+    "searchDoctor": "Tìm bác sĩ theo tên",
+    "filterByDate": "Có lịch ngày",
+    "clearDateFilter": "Xóa lọc ngày",
+    "noDoctorMatch": "Không có bác sĩ phù hợp bộ lọc",
+    "selectedDoctor": "Bác sĩ đã chọn",
+    "changeDoctor": "Đổi bác sĩ",
+    "slotUnavailableTitle": "Không đặt được khung giờ",
+    "slotUnavailable": "Khung giờ đã được đặt hoặc không còn trống. Vui lòng chọn giờ khác."
 }

--- a/public/locales/vi/doctor-schedule.json
+++ b/public/locales/vi/doctor-schedule.json
@@ -17,5 +17,7 @@
     "week": "Tuần",
     "doctorScheduleTitle": "Thống kê lịch tuần của bác sĩ",
     "confirmCreateSchedule": "Xác nhận tạo lịch tuần này?",
-    "confirmUpdateSchedule": "Xác nhận cập nhật lịch tuần này?"
+    "confirmUpdateSchedule": "Xác nhận cập nhật lịch tuần này?",
+    "updateBlockedTitle": "Không thể cập nhật lịch tuần",
+    "updateBlockedHasBookings": "Tuần này đã có lịch khám của bệnh nhân. Hủy hoặc chuyển lịch trước khi cập nhật ca làm việc."
 }

--- a/src/modules/pages/BookingComponents/BookingDoctorDiscovery/index.jsx
+++ b/src/modules/pages/BookingComponents/BookingDoctorDiscovery/index.jsx
@@ -1,0 +1,209 @@
+import { Box, Button, Chip, TextField } from "@mui/material"
+import { useEffect, useMemo, useState } from "react"
+import { useTranslation } from "react-i18next"
+import moment from "moment"
+import { CURRENT_DATE } from "../../../../lib/constants"
+import { fetchSchedulesForDoctors } from "../services"
+import BookingForm from "../BookingForm"
+import Loading from "../../../common/components/Loading"
+
+const doctorDisplayName = (doctor) => {
+  const u = doctor?.user_display || {}
+  return `${u.first_name || ""} ${u.last_name || ""}`.trim()
+}
+
+const doctorHasOpenSession = (schedules) =>
+  Array.isArray(schedules) &&
+  schedules.some((s) => s && s.is_off === false)
+
+/**
+ * P3 discovery: specialty + name + optional date → pick one doctor → single BookingForm.
+ */
+const BookingDoctorDiscovery = ({ doctors = [] }) => {
+  const { t } = useTranslation(["booking", "common"])
+  const [specialtyId, setSpecialtyId] = useState("all")
+  const [nameQuery, setNameQuery] = useState("")
+  const [filterDate, setFilterDate] = useState("")
+  const [dateAvailableIds, setDateAvailableIds] = useState(null)
+  const [dateFilterLoading, setDateFilterLoading] = useState(false)
+  const [selectedDoctorId, setSelectedDoctorId] = useState(null)
+
+  const specialtyOptions = useMemo(() => {
+    const map = new Map()
+    doctors.forEach((d) => {
+      ;(d.specializations || []).forEach((s) => {
+        if (s?.id != null && !map.has(s.id)) map.set(s.id, s.name)
+      })
+    })
+    return Array.from(map.entries()).map(([id, name]) => ({ id, name }))
+  }, [doctors])
+
+  const specialtyFiltered = useMemo(() => {
+    let list = doctors
+    if (specialtyId !== "all") {
+      list = list.filter((d) =>
+        (d.specializations || []).some((s) => String(s.id) === String(specialtyId))
+      )
+    }
+    const q = nameQuery.trim().toLowerCase()
+    if (q) {
+      list = list.filter((d) => doctorDisplayName(d).toLowerCase().includes(q))
+    }
+    return list
+  }, [doctors, specialtyId, nameQuery])
+
+  const specialtyFilteredIdsKey = specialtyFiltered
+    .map((d) => d.user_display?.id)
+    .filter(Boolean)
+    .join(",")
+
+  useEffect(() => {
+    let cancelled = false
+    const run = async () => {
+      if (!filterDate) {
+        setDateAvailableIds(null)
+        return
+      }
+      setDateFilterLoading(true)
+      try {
+        const ids = specialtyFilteredIdsKey
+          ? specialtyFilteredIdsKey.split(",").map((id) => Number(id))
+          : []
+        const rows = await fetchSchedulesForDoctors(filterDate, ids)
+        if (cancelled) return
+        const open = new Set(
+          rows.filter((r) => doctorHasOpenSession(r.schedules)).map((r) => r.doctorId)
+        )
+        setDateAvailableIds(open)
+      } catch {
+        if (!cancelled) setDateAvailableIds(new Set())
+      } finally {
+        if (!cancelled) setDateFilterLoading(false)
+      }
+    }
+    run()
+    return () => {
+      cancelled = true
+    }
+  }, [filterDate, specialtyFilteredIdsKey])
+
+  const visibleDoctors = useMemo(() => {
+    if (!dateAvailableIds) return specialtyFiltered
+    return specialtyFiltered.filter((d) =>
+      dateAvailableIds.has(d.user_display?.id)
+    )
+  }, [specialtyFiltered, dateAvailableIds])
+
+  const selectedDoctor = useMemo(
+    () => doctors.find((d) => d.id === selectedDoctorId) || null,
+    [doctors, selectedDoctorId]
+  )
+
+  if (selectedDoctor) {
+    return (
+      <Box>
+        <Box className="ou-flex ou-justify-between ou-items-center ou-mb-3 ou-px-2">
+          <span className="ou-text-sm ou-text-gray-600">
+            {t("booking:selectedDoctor")}:{" "}
+            <strong className="ou-text-blue-700">
+              {doctorDisplayName(selectedDoctor)}
+            </strong>
+          </span>
+          <Button size="small" variant="outlined" onClick={() => setSelectedDoctorId(null)}>
+            {t("booking:changeDoctor")}
+          </Button>
+        </Box>
+        <BookingForm doctorInfo={selectedDoctor} key={selectedDoctor.id} />
+      </Box>
+    )
+  }
+
+  return (
+    <Box className="ou-w-full ou-text-left">
+      <Box className="ou-mb-3 ou-px-1">
+        <p className="ou-text-sm ou-font-semibold ou-mb-2">{t("booking:filterBySpecialty")}</p>
+        <Box className="ou-flex ou-flex-wrap ou-gap-2">
+          <Chip
+            label={t("booking:allSpecialties")}
+            color={specialtyId === "all" ? "primary" : "default"}
+            onClick={() => setSpecialtyId("all")}
+            variant={specialtyId === "all" ? "filled" : "outlined"}
+          />
+          {specialtyOptions.map((s) => (
+            <Chip
+              key={s.id}
+              label={s.name}
+              color={String(specialtyId) === String(s.id) ? "primary" : "default"}
+              onClick={() => setSpecialtyId(s.id)}
+              variant={String(specialtyId) === String(s.id) ? "filled" : "outlined"}
+            />
+          ))}
+        </Box>
+      </Box>
+
+      <Box
+        className="ou-flex ou-flex-col ou-gap-3 ou-mb-4 ou-px-1"
+        sx={{ flexDirection: { sm: "row" }, alignItems: { sm: "center" } }}
+      >
+        <TextField
+          size="small"
+          fullWidth
+          label={t("booking:searchDoctor")}
+          value={nameQuery}
+          onChange={(e) => setNameQuery(e.target.value)}
+        />
+        <TextField
+          size="small"
+          type="date"
+          label={t("booking:filterByDate")}
+          value={filterDate}
+          onChange={(e) => setFilterDate(e.target.value)}
+          InputLabelProps={{ shrink: true }}
+          inputProps={{
+            min: moment(CURRENT_DATE).format("YYYY-MM-DD"),
+            max: moment(CURRENT_DATE).add(30, "days").format("YYYY-MM-DD"),
+          }}
+          sx={{ minWidth: { sm: 200 } }}
+        />
+        {filterDate ? (
+          <Button size="small" onClick={() => setFilterDate("")}>
+            {t("booking:clearDateFilter")}
+          </Button>
+        ) : null}
+      </Box>
+
+      {dateFilterLoading ? (
+        <Box className="ou-py-6">
+          <Loading />
+        </Box>
+      ) : visibleDoctors.length === 0 ? (
+        <p className="ou-text-center ou-text-gray-600 ou-py-6">{t("booking:noDoctorMatch")}</p>
+      ) : (
+        <Box className="ou-flex ou-flex-col ou-gap-2">
+          {visibleDoctors.map((d) => (
+            <button
+              type="button"
+              key={d.id}
+              onClick={() => setSelectedDoctorId(d.id)}
+              className="ou-w-full ou-text-left ou-border ou-border-blue-100 ou-rounded-md ou-p-3 hover:ou-bg-blue-50 ou-transition"
+            >
+              <div className="ou-font-semibold ou-text-blue-700">{doctorDisplayName(d)}</div>
+              <div className="ou-flex ou-flex-wrap ou-gap-1 ou-mt-1">
+                {(d.specializations || []).map((s) => (
+                  <span
+                    key={`${d.id}-${s.id}`}
+                    className="ou-bg-blue-50 ou-text-blue-700 ou-px-2 ou-py-0.5 ou-rounded ou-text-xs"
+                  >
+                    {s.name}
+                  </span>
+                ))}
+              </div>
+            </button>
+          ))}
+        </Box>
+      )}
+    </Box>
+  )
+}
+
+export default BookingDoctorDiscovery

--- a/src/modules/pages/BookingComponents/BookingForm/index.jsx
+++ b/src/modules/pages/BookingComponents/BookingForm/index.jsx
@@ -1,4 +1,4 @@
-import { Avatar, Box, Button, Container, Divider, FormControl, Grid, InputLabel, MenuItem, OutlinedInput, Paper, Select, TextField } from "@mui/material"
+import { Avatar, Box, Button, Container, Divider, FormControl, Grid, InputLabel, OutlinedInput, Paper, TextField } from "@mui/material"
 import moment from "moment"
 import { CURRENT_DATE } from "../../../../lib/constants"
 import DoctorAvailabilityTime from "../DoctorAvailabilityTime"
@@ -8,7 +8,7 @@ import useDoctorAvailability from "../DoctorAvailabilityTime/hooks/useDoctorAvai
 import clsx from "clsx"
 import { useForm } from "react-hook-form"
 import { yupResolver } from "@hookform/resolvers/yup"
-import { useContext, useEffect, useState } from "react"
+import { useContext, useEffect } from "react"
 import CustomCollapseListItemButton from "../../../common/components/collapse/ListItemButton"
 import BookingContext from "../../../../lib/context/BookingContext"
 import StethoscopeIcon from "../../../../lib/icon/StethoscopeIcon"
@@ -16,34 +16,17 @@ import SchemaModels from "../../../../lib/schema"
 import useCustomModal from "../../../../lib/hooks/useCustomModal"
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import Tooltip from '@mui/material/Tooltip';
-import UserContext from "../../../../lib/context/UserContext"
-import UpdateAddressInfo from "../../ProfileComponents/UpdateAddressInfo"
-import useUserAddresses from "../../ProfileComponents/hooks/useUserAddresses"
-import CloseIcon from '@mui/icons-material/Close';
 
 const BookingForm = ({doctorInfo}) => {
-    const {t , tReady} = useTranslation(['booking', 'yup-validate', 'modal', 'home', 'register'])
+    const {t , tReady} = useTranslation(['booking', 'yup-validate', 'modal', 'home', 'common'])
 
     const doctor = doctorInfo;
     const {patientSelected, actionUpState} = useContext(BookingContext)
-    const { user, hasValidUserAddress, defaultAddress } = useContext(UserContext)
-    const { handleCreateAddress } = useUserAddresses()
     const {timeNotAvailable, isLoading, setDate, slideRight, 
         handleSlideChange, setDoctorID, onSubmit} = useDoctorAvailability();
     
     const { timeSlotSchema } = SchemaModels()
     const { handleCloseModal, handleOpenModal, isOpen } = useCustomModal();
-    const { handleCloseModal: handleCloseAddressModal, handleOpenModal: handleOpenAddressModal, isOpen: isAddressModalOpen } = useCustomModal();
-
-    const addresses = Array.isArray(user?.addresses) ? user.addresses : []
-    const [selectedAddressId, setSelectedAddressId] = useState(defaultAddress?.id ?? addresses[0]?.id ?? null)
-    const [pendingBookingData, setPendingBookingData] = useState(null);
-
-    useEffect(() => {
-        const list = Array.isArray(user?.addresses) ? user.addresses : []
-        const defaultId = defaultAddress?.id ?? list[0]?.id ?? null
-        setSelectedAddressId((prev) => (list.some((a) => a.id === prev) ? prev : defaultId))
-    }, [user?.addresses, defaultAddress?.id])
 
     useEffect(()=>{setDoctorID(doctor.user_display.id)},[doctor.user_display.id])
 
@@ -77,30 +60,7 @@ const BookingForm = ({doctorInfo}) => {
         methods.trigger("selectedDate");
     };
 
-    // Handle add address (modal) and continue with booking
-    const handleAddressSubmit = (data, setError, locationGeo, cityName, districtName) => {
-        handleCreateAddress(data, setError, locationGeo, cityName, districtName, () => {
-            handleCloseAddressModal();
-            if (pendingBookingData) {
-                onSubmit(pendingBookingData, patientSelected, () => {
-                    methods.reset();
-                    actionUpState();
-                }, methods.setError);
-                setPendingBookingData(null);
-            }
-        });
-    };
-
-    // Modified submit handler to check address first
     const handleBookingSubmit = (data) => {
-        if (!hasValidUserAddress) {
-            // Store booking data and show address modal
-            setPendingBookingData(data);
-            handleOpenAddressModal();
-            return;
-        }
-        
-        // Proceed with booking if address is valid
         onSubmit(data, patientSelected, () => {
             methods.reset(); 
             actionUpState();
@@ -206,33 +166,6 @@ const BookingForm = ({doctorInfo}) => {
             </div>
             <h5 className="ou-text-center ou-text-xl ou-py-2 ou-mt-2">{t('home:makeAnAppointMent')}</h5>
 
-            {hasValidUserAddress && addresses.length > 0 && (
-                <Grid item xs={12} className="!ou-p-4 !ou-pt-0">
-                    <FormControl fullWidth size="small">
-                        <InputLabel id="booking-address-label">{t('booking:address')}</InputLabel>
-                        <Select
-                            labelId="booking-address-label"
-                            value={selectedAddressId ?? ''}
-                            label={t('booking:address')}
-                            onChange={(e) => setSelectedAddressId(e.target.value)}
-                        >
-                            {addresses.map((addr) => (
-                                <MenuItem key={addr.id} value={addr.id}>
-                                    {addr.address}
-                                    {(addr.city_info?.name || addr.district_info?.name) && ` — ${[addr.district_info?.name, addr.city_info?.name].filter(Boolean).join(', ')}`}
-                                    {addr.is_default && ` (${t('booking:default')})`}
-                                </MenuItem>
-                            ))}
-                        </Select>
-                    </FormControl>
-                    <Box className="ou-mt-2">
-                        <Button size="small" variant="text" color="primary" onClick={handleOpenAddressModal}>
-                            {t('register:addAddress')}
-                        </Button>
-                    </Box>
-                </Grid>
-            )}
-
             <Grid item xs={12} className="!ou-p-4" >
                 <FormControl fullWidth >
                     <InputLabel htmlFor="description">{t('description')}</InputLabel>
@@ -261,9 +194,7 @@ const BookingForm = ({doctorInfo}) => {
                 <Box className="ou-flex ou-py-4" component={Paper} elevation={4} >           
                     <div className="ou-w-[100%]">
                         <form onSubmit={methods.handleSubmit(handleBookingSubmit)} className="ou-m-auto ou-px-5"> 
-                            {/* Patient Form required */}
                             {renderPatientInformationForm(slideRight)}
-                            {/* Area button */}
                             <Grid item className="!ou-my-3 ou-flex ou-justify-end">
                                 {!slideRight ?  disableButton() : 
                                     <Box className="ou-flex ou-justify-end ou-mb-3 ou-w-full">
@@ -291,7 +222,6 @@ const BookingForm = ({doctorInfo}) => {
                 </Box>
             </Container>
 
-            {/* Doctor Detail Modal */}
             {isOpen && (
                 <DoctorDetailModal 
                     open={isOpen} 
@@ -299,41 +229,11 @@ const BookingForm = ({doctorInfo}) => {
                     doctor={doctor}
                 />
             )}
-
-            {/* Address Update Modal */}
-            {isAddressModalOpen && (
-                <div className={`ou-fixed ou-inset-0 ou-bg-black ou-bg-opacity-50 ou-flex ou-items-center ou-justify-center ou-z-50 ${isAddressModalOpen ? 'ou-block' : 'ou-hidden'}`}>
-                    <div className="ou-bg-white ou-rounded-lg ou-shadow-lg ou-max-w-2xl ou-w-full ou-mx-4 ou-max-h-[90vh] ou-overflow-y-auto">
-                        <div className="ou-p-6">
-                            <div className="ou-flex ou-justify-between ou-items-center ou-mb-4">
-                                <h2 className="ou-text-xl ou-text-gray-800">
-                                    {t('register:updateAddressInfo')}
-                                </h2>
-                                <button 
-                                    onClick={handleCloseAddressModal}
-                                    className="ou-text-gray-500 hover:ou-text-gray-700 ou-text-2xl"
-                                >
-                                    <CloseIcon />
-                                </button>
-                            </div>
-                            
-                            <div className="ou-mb-4">
-                                <p className="ou-text-gray-600 ou-text-sm">
-                                    {t('booking:addressRequiredForBooking')}
-                                </p>
-                            </div>
-                            
-                            <UpdateAddressInfo onSubmit={handleAddressSubmit} submitLabel={t('register:addAddress')}/>
-                        </div>
-                    </div>
-                </div>
-            )}
         </>
     )
 }
 
 const SpecializationTag = ({specialization}) => {
-    const {t} = useTranslation(['booking'])
     if(!specialization)
         return <></>
     return (

--- a/src/modules/pages/BookingComponents/DoctorAvailabilityTime/hooks/useDoctorAvailability.js
+++ b/src/modules/pages/BookingComponents/DoctorAvailabilityTime/hooks/useDoctorAvailability.js
@@ -2,8 +2,8 @@ import { useEffect, useState } from "react"
 import { fetchCreateTimeSlot, fetchGetDoctorAvailability } from "../../services";
 import useDebounce from "../../../../../lib/hooks/useDebounce";
 import moment from "moment";
-import { fetchCreateExamination, fetchCreateOrUpdatePatient, fetchExamDateData } from "../../FormAddExamination/services";
-import { TOAST_SUCCESS } from "../../../../../lib/constants";
+import { fetchCreateExamination, fetchCreateOrUpdatePatient } from "../../FormAddExamination/services";
+import { TOAST_ERROR, TOAST_SUCCESS } from "../../../../../lib/constants";
 import { useTranslation } from "react-i18next";
 import { ConfirmAlert, ErrorAlert } from "../../../../../config/sweetAlert2";
 import createToastMessage from "../../../../../lib/utils/createToastMessage";
@@ -21,8 +21,6 @@ const useDoctorAvailability = () => {
     const debouncedValueDoctor = useDebounce(doctorID, 500)
 
     const [isLoading, setIsLoading] = useState(false)
-
-    const [examinationDateData, setExaminationDateData] = useState([]);
     const [slideRight, setSlideRight] = useState(false)    
 
 
@@ -38,36 +36,9 @@ const useDoctorAvailability = () => {
         return new Date(`${selectedDate}T${selectedTime}`)
     };
 
-
-    const shouldDisableTime = (time) => {
-        const selectedDate = moment(debouncedValue).format('YYYY-MM-DD');
-        const disabledTimesFromData = examinationDateData
-            .filter((e) => e.created_date.includes(selectedDate))
-            .map((e) => moment(e.created_date).format('HH:mm:ss'));
-
-        const isDisabledRange = (time.hour() >= 0 && time.hour() < 7) || (time.hour() > 17 && time.hour() <= 23);
-
-        return (
-            disabledTimesFromData.includes(time.format('HH:mm:ss')) || isDisabledRange
-        );
-    };
-
     const handleChangeFlag = () => setFlag(!flag);
 
     useEffect(()=> {
-        const getExaminationDateData = async (date) => {
-            try {
-              const res = await fetchExamDateData(date);
-              if (res.status === 200) {
-                setExaminationDateData(res.data.examinations);
-              }
-            } catch (error) {
-              console.error(error);
-            }finally {
-              setIsLoading(false)
-            }
-          };
-
         const getDoctorAvailability = async (date, doctor) => {
             try{
                 const res = await fetchGetDoctorAvailability(date, parseInt(doctor))
@@ -76,6 +47,7 @@ const useDoctorAvailability = () => {
                 }
             } catch( err){
                 console.log(err)
+                setTimeNotAvailable([])
             }finally {
                 setIsLoading(false)
               }
@@ -84,13 +56,7 @@ const useDoctorAvailability = () => {
             setIsLoading(true)
             getDoctorAvailability(debouncedValue, debouncedValueDoctor)
         }
-        if (debouncedValue) {
-            setIsLoading(true)
-            getExaminationDateData(debouncedValue);
-        }
     },[debouncedValue, debouncedValueDoctor, flag])
-
-
 
     
     const onSubmit = async (data, patientData ,callbackSuccess, callbackFail) => {
@@ -116,37 +82,59 @@ const useDoctorAvailability = () => {
                     handleOnSubmit(res.data.id)
                 }
             }catch(err){
-                console.log(err)
+                const apiMsg = err?.response?.data?.errMsg
+                ErrorAlert(
+                    t('booking:slotUnavailableTitle'),
+                    apiMsg || t('booking:slotUnavailable'),
+                    t('modal:ok'),
+                )
+                createToastMessage({
+                    type: TOAST_ERROR,
+                    message: apiMsg || t('booking:slotUnavailable'),
+                })
+                handleChangeFlag()
             }
 
         }
 
         const handleOnSubmit = async (timeSlot) => {
-            // Update done or created patient info
-            const res = await fetchCreateOrUpdatePatient(patientData.id, patientData);
-         
-            if(res.status === 200 || res.status === 201){
-                const examinationData = {
-                    patient: res.data.id,
-                    description: data.description,
-                    created_date: new Date(data.selectedDate),
-                    time_slot: timeSlot
-                }
-                const resExamination = await fetchCreateExamination(examinationData);
-                if(resExamination.status === 201){
-                    createToastMessage({message:t('modal:createSuccess'), type:TOAST_SUCCESS})
-                    callbackSuccess();
-                    setSlideRight(false);
-                    handleChangeFlag();
+            try {
+                const res = await fetchCreateOrUpdatePatient(patientData.id, patientData);
+             
+                if(res.status === 200 || res.status === 201){
+                    const examinationData = {
+                        patient: res.data.id,
+                        description: data.description,
+                        created_date: new Date(data.selectedDate),
+                        time_slot: timeSlot
+                    }
+                    try {
+                        const resExamination = await fetchCreateExamination(examinationData);
+                        if(resExamination.status === 201){
+                            createToastMessage({message:t('modal:createSuccess'), type:TOAST_SUCCESS})
+                            callbackSuccess();
+                            setSlideRight(false);
+                            handleChangeFlag();
+                        } else {
+                            return ErrorAlert(t('modal:errSomethingWentWrong'), t('modal:pleaseTryAgain'), t('modal:ok'));
+                        }
+                    } catch (examErr) {
+                        const apiMsg = examErr?.response?.data?.errMsg
+                        ErrorAlert(
+                            t('booking:slotUnavailableTitle'),
+                            apiMsg || t('modal:errSomethingWentWrong'),
+                            t('modal:ok'),
+                        )
+                        createToastMessage({
+                            type: TOAST_ERROR,
+                            message: apiMsg || t('booking:slotUnavailable'),
+                        })
+                    }
                 }
                 else{
                     return ErrorAlert(t('modal:errSomethingWentWrong'), t('modal:pleaseTryAgain'), t('modal:ok'));
                 }
-                if(resExamination.status === 500){
-                    return ErrorAlert(t('modal:errSomethingWentWrong'), t('modal:pleaseTryAgain'), t('modal:ok'));
-                }
-            }
-            else{
+            } catch {
                 return ErrorAlert(t('modal:errSomethingWentWrong'), t('modal:pleaseTryAgain'), t('modal:ok'));
             }
         }
@@ -161,7 +149,7 @@ const useDoctorAvailability = () => {
     return {
         setDoctorID, doctorID, timeNotAvailable, onSubmit,
         isLoading, setDate, date, handleTimeChange,
-        setTime, time, shouldDisableTime,
+        setTime, time,
         slideRight, handleSlideChange
     }
 }

--- a/src/modules/pages/BookingComponents/services/index.js
+++ b/src/modules/pages/BookingComponents/services/index.js
@@ -29,6 +29,24 @@ export const fetchCreateTimeSlot = async (data) => {
     return res;
 }
 
+/** P3 date-filter: parallel schedule lookups (reuse existing schedule-by-date API). */
+export const fetchSchedulesForDoctors = async (date, doctorIds = []) => {
+    const results = await Promise.all(
+        doctorIds.map(async (doctorId) => {
+            try {
+                const res = await fetchGetDoctorAvailability(date, parseInt(doctorId, 10))
+                return {
+                    doctorId: parseInt(doctorId, 10),
+                    schedules: res.status === 200 ? res.data : [],
+                }
+            } catch {
+                return { doctorId: parseInt(doctorId, 10), schedules: [] }
+            }
+        })
+    )
+    return results
+}
+
 export const fetchDeleteTimeSlot = async (timeSlotID) => {
     const res = await authApi().delete(endpoints['time-slot-detail'](timeSlotID))
     return res;

--- a/src/modules/pages/DoctorScheduleComponents/hooks/useDoctorSchedule.js
+++ b/src/modules/pages/DoctorScheduleComponents/hooks/useDoctorSchedule.js
@@ -1,11 +1,11 @@
 import { useContext, useEffect, useState } from "react"
 import { fetchCheckWeeklySchedule, fetchCreateDoctorScheduleByWeek, fetchUpdateDoctorSchedule } from "../services"
 import { useTranslation } from "react-i18next"
-import { ConfirmAlert } from "../../../../config/sweetAlert2"
+import { ConfirmAlert, ErrorAlert } from "../../../../config/sweetAlert2"
 import { useSearchParams } from "react-router-dom"
 import moment from "moment"
 import UserContext from "../../../../lib/context/UserContext"
-import { TOAST_SUCCESS } from "../../../../lib/constants"
+import { TOAST_ERROR, TOAST_SUCCESS } from "../../../../lib/constants"
 import createToastMessage from "../../../../lib/utils/createToastMessage"
 
 const useDoctorSchedule = () => {
@@ -68,7 +68,25 @@ const useDoctorSchedule = () => {
                     setFlag(prev => !prev)
                 }
             }catch (err) {
-                console.log(err)
+                const apiMsg = err?.response?.data?.errMsg
+                const errCode = err?.response?.data?.errCode
+                if (errCode === 'HAS_BOOKINGS' || apiMsg) {
+                    ErrorAlert(
+                        t('doctor-schedule:updateBlockedTitle'),
+                        apiMsg || t('doctor-schedule:updateBlockedHasBookings'),
+                        t('modal:ok'),
+                    )
+                    createToastMessage({
+                        type: TOAST_ERROR,
+                        message: t('doctor-schedule:updateBlockedHasBookings'),
+                    })
+                } else {
+                    ErrorAlert(
+                        t('modal:errSomethingWentWrong'),
+                        t('modal:pleaseTryAgain'),
+                        t('modal:ok'),
+                    )
+                }
             } finally {
                 setIsLoading(false);
             }

--- a/src/pages/booking/index.jsx
+++ b/src/pages/booking/index.jsx
@@ -17,7 +17,7 @@ import PatientCard from "../../modules/common/components/card/PatientCard";
 import BookingProcess from "../../modules/pages/BookingComponents/BookingProcess";
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import { useNavigate } from "react-router";
-import BookingForm from "../../modules/pages/BookingComponents/BookingForm";
+import BookingDoctorDiscovery from "../../modules/pages/BookingComponents/BookingDoctorDiscovery";
 
 // Constants for reusable styles
 const BUTTON_STYLES = {
@@ -218,12 +218,16 @@ const Booking = () => {
         )
     
     }
-    // Step 3
+    // Step 3 — discovery then single doctor booking panel (MASTER P3)
     const renderThirdState = () => {
-        return (<Box>
-            {allConfig && allConfig.doctors ? allConfig.doctors.map((d)=> 
-                <BookingForm doctorInfo={d} key={d.id}/>) : <></>}
-        </Box>)
+        if (!allConfig?.doctors?.length) {
+            return <p className="ou-text-gray-600">{t('booking:noDoctorFound')}</p>
+        }
+        return (
+            <Box>
+                <BookingDoctorDiscovery doctors={allConfig.doctors} />
+            </Box>
+        )
     }
 
     // Step 4 


### PR DESCRIPTION
## Summary
- **P3:** Step 3 discovery — specialty chips, name search, optional date filter (`Promise.all` schedules), then **one** `BookingForm`.
- Remove fake address UI/gate from booking form.
- Harden slot create/exam errors with toast + ErrorAlert (P1 400s).
- **P2 FE:** surface `HAS_BOOKINGS` when doctor weekly update fails (pairs with BE P2).

No dashboard calendar redesign, no cover/diff (P4+).

## Test plan
- [ ] `/booking` step 3: filter specialty → short list → select one doctor → date/time form only
- [ ] Date filter hides doctors without open session that day
- [ ] Double-book slot shows user-facing error
- [ ] Doctor schedule Cập nhật with bookings → ErrorAlert (needs BE P2 merged/running)
- [ ] Steps 1–2–4 unchanged

